### PR TITLE
Fix: auto-approve for terraform apply

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -35,7 +35,7 @@ jobs:
           -input=false
           
           terraform apply \
-          -var-file=vars.tfvars
+          -var-file=vars.tfvars \
           -input=false \
           -auto-approve 
           


### PR DESCRIPTION
Following along with your guide and found that `terraform apply` failed with the following errors:

```
Error: error asking for approval: EOF
```

Looks like the newline wasn't properly escaped here.

Thanks for the guide, it's helped me a lot!